### PR TITLE
Adding identity interceptor OSGi tests.

### DIFF
--- a/components/org.wso2.carbon.identity.mgt/pom.xml
+++ b/components/org.wso2.carbon.identity.mgt/pom.xml
@@ -90,6 +90,10 @@
             <groupId>org.wso2.carbon.datasources</groupId>
             <artifactId>org.wso2.carbon.datasource.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.commons</groupId>
+            <artifactId>org.wso2.carbon.identity.commons</artifactId>
+        </dependency>
         <!-- Dependencies for unit tests -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -137,6 +141,7 @@
             org.wso2.carbon.messaging.*,
             org.wso2.carbon.caching.*,
             org.wso2.carbon.datasource.core.*;version="${org.wso2.carbon.datasource.version.range}",
+            org.wso2.carbon.identity.common.*,
         </import.package>
 
         <carbon.component>
@@ -144,7 +149,9 @@
             componentName="wso2-carbon-identity-mgt";
             requiredService="
             org.wso2.carbon.identity.mgt.connector.CredentialStoreConnectorFactory,
-            org.wso2.carbon.identity.mgt.connector.IdentityStoreConnectorFactory"
+            org.wso2.carbon.identity.mgt.connector.IdentityStoreConnectorFactory,
+            org.wso2.carbon.identity.common.util.IdentityUtilService,
+            org.wso2.carbon.identity.mgt.interceptor.IdentityStoreInterceptor"
         </carbon.component>
 
         <!-- OSGi API version range-->

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/internal/IdentityMgtDataHolder.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/internal/IdentityMgtDataHolder.java
@@ -19,12 +19,14 @@ package org.wso2.carbon.identity.mgt.impl.internal;
 import org.wso2.carbon.caching.CarbonCachingService;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
+import org.wso2.carbon.identity.common.util.IdentityUtilService;
 import org.wso2.carbon.identity.mgt.AuthorizationStore;
 import org.wso2.carbon.identity.mgt.RealmService;
 import org.wso2.carbon.identity.mgt.connector.AuthorizationStoreConnectorFactory;
 import org.wso2.carbon.identity.mgt.connector.CredentialStoreConnectorFactory;
 import org.wso2.carbon.identity.mgt.connector.IdentityStoreConnectorFactory;
 import org.wso2.carbon.identity.mgt.impl.JDBCUniqueIdResolverFactory;
+import org.wso2.carbon.identity.mgt.impl.internal.config.interceptor.InterceptorEntry;
 import org.wso2.carbon.identity.mgt.interceptor.IdentityStoreInterceptor;
 import org.wso2.carbon.identity.mgt.resolver.UniqueIdResolverFactory;
 
@@ -54,6 +56,8 @@ public class IdentityMgtDataHolder {
 
     private DataSourceService dataSourceService;
 
+    private IdentityUtilService identityUtilService;
+
     private Map<String, CredentialStoreConnectorFactory> credentialStoreConnectorFactoryMap = new HashMap<>();
 
     private Map<String, IdentityStoreConnectorFactory> identityStoreConnectorFactoryMap = new HashMap<>();
@@ -61,6 +65,8 @@ public class IdentityMgtDataHolder {
     private Map<String, UniqueIdResolverFactory> uniqueIdResolverFactoryMap = new HashMap<>();
 
     private Map<String, AuthorizationStoreConnectorFactory> authorizationStoreConnectorFactoryMap = new HashMap<>();
+
+    private Map<String, InterceptorEntry> identityStoreInterceptorConfigMap = new HashMap<>();
 
     private List<IdentityStoreInterceptor> identityStoreInterceptors = new ArrayList<>();
 
@@ -224,12 +230,33 @@ public class IdentityMgtDataHolder {
      */
     public void registerIdentityStoreInterceptor(IdentityStoreInterceptor identityStoreInterceptor) {
 
-        if (identityStoreInterceptor.isEnabled()) {
-            identityStoreInterceptors.add(identityStoreInterceptor);
-            identityStoreInterceptors.sort((identityStoreInterceptor1, identityStoreInterceptor2) ->
-                                                   identityStoreInterceptor1.getExecutionOrderId() -
-                                                   identityStoreInterceptor2.getExecutionOrderId());
+        identityStoreInterceptors.add(identityStoreInterceptor);
+    }
 
-        }
+    /**
+     * Register an instance of IdentityUtilService.
+     *
+     * @param identityUtilService IdentityUtilService service instance.
+     */
+    public void registerIdentityUtilService(IdentityUtilService identityUtilService) {
+        this.identityUtilService = identityUtilService;
+    }
+
+    /**
+     * Returns the IdentityUtilService.
+     *
+     * @return IdentityUtilService.
+     */
+    public IdentityUtilService getIdentityUtilService() {
+        return identityUtilService;
+    }
+
+    /**
+     * Returns all identity store interceptor configs.
+     *
+     * @return Map of identity interceptor configs.
+     */
+    public Map<String, InterceptorEntry> getIdentityStoreInterceptorConfigMap() {
+        return identityStoreInterceptorConfigMap;
     }
 }

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/internal/config/interceptor/IdentityStoreInterceptorConfigs.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/internal/config/interceptor/IdentityStoreInterceptorConfigs.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.impl.internal.config.interceptor;
+
+import java.util.List;
+
+/**
+ * This class represents all the config entries for identity store interceptors.
+ */
+public class IdentityStoreInterceptorConfigs {
+
+    private List<InterceptorEntry> identityStoreInterceptors;
+
+    public List<InterceptorEntry> getIdentityStoreInterceptors() {
+        return identityStoreInterceptors;
+    }
+
+    public void setIdentityStoreInterceptors(List<InterceptorEntry> identityStoreInterceptors) {
+        this.identityStoreInterceptors = identityStoreInterceptors;
+    }
+}

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/internal/config/interceptor/InterceptorEntry.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/internal/config/interceptor/InterceptorEntry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.impl.internal.config.interceptor;
+
+/**
+ * This class represents a config entry for an interceptor.
+ */
+public class InterceptorEntry {
+
+    private String name;
+    private boolean enable;
+    private int orderID;
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getOrderID() {
+        return orderID;
+    }
+
+    public void setOrderID(int order) {
+        this.orderID = order;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/interceptor/IdentityStoreInterceptor.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/interceptor/IdentityStoreInterceptor.java
@@ -47,13 +47,6 @@ public interface IdentityStoreInterceptor {
     int getExecutionOrderId();
 
     /**
-     * Get whether the interceptor is enabled or not.
-     *
-     * @return If interceptor is enables returns true, otherwise false.
-     */
-    boolean isEnabled();
-
-    /**
      * Triggers prior to getting the user from unique user ID.
      *
      * @param uniqueUserId Unique user ID of the user.
@@ -998,7 +991,7 @@ public interface IdentityStoreInterceptor {
      * @param claim User claim.
      * @param credentials Callbacks with credentials.
      * @param domainName The domain name to authenticate the user against.
-     * @throws AuthenticationFailure
+     * @throws AuthenticationFailure Authentication failure.
      * @throws IdentityStoreException Identity store exception.
      */
     void doPreAuthenticate(Claim claim, Callback[] credentials, String domainName) throws AuthenticationFailure,
@@ -1011,7 +1004,7 @@ public interface IdentityStoreInterceptor {
      * @param credentials Callbacks with credentials.
      * @param domainName The domain name to authenticate the user against.
      * @param authenticationContext AuthenticationContext result to be returned from authenticate method.
-     * @throws AuthenticationFailure
+     * @throws AuthenticationFailure Authentication failure.
      * @throws IdentityStoreException Identity store exception.
      */
     void doPostAuthenticate(Claim claim, Callback[] credentials, String domainName, AuthenticationContext

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryException.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryException.java
@@ -30,22 +30,18 @@ public class IdentityRecoveryException extends IdentityException {
 
     public IdentityRecoveryException(String message) {
         super(message);
-        this.setErrorCode(getDefaultErrorCode());
     }
 
     public IdentityRecoveryException(String message, Throwable cause) {
         super(message, cause);
-        this.setErrorCode(getDefaultErrorCode());
     }
 
     public IdentityRecoveryException(String errorCode, String message) {
         super(errorCode, message);
-        this.setErrorCode(errorCode);
     }
 
     public IdentityRecoveryException(String errorCode, String message, Throwable throwable) {
         super(errorCode, message, throwable);
-        this.setErrorCode(errorCode);
     }
     
     public String getErrorDescription() {
@@ -56,14 +52,4 @@ public class IdentityRecoveryException extends IdentityException {
         }
         return errorDescription;
     }
-
-    private String getDefaultErrorCode() {
-
-        String errorCode = super.getErrorCode();
-        if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED.getCode();
-        }
-        return errorCode;
-    }
-
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -22,7 +22,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.identity.common.base.exception.IdentityException;
 import org.wso2.carbon.identity.mgt.IdentityStore;
 import org.wso2.carbon.identity.mgt.RealmService;
 import org.wso2.carbon.identity.mgt.User;
@@ -155,8 +154,7 @@ public class Utils {
             errorDescription = error.getMessage();
         }
 
-        return IdentityException.error(
-                IdentityRecoveryServerException.class, error.getCode(), errorDescription);
+        return new IdentityRecoveryServerException(error.getCode(), errorDescription);
     }
 
     public static IdentityRecoveryServerException handleServerException(IdentityRecoveryConstants.ErrorMessages
@@ -170,8 +168,7 @@ public class Utils {
             errorDescription = error.getMessage();
         }
 
-        return IdentityException.error(
-                IdentityRecoveryServerException.class, error.getCode(), errorDescription, e);
+        return new IdentityRecoveryServerException(error.getCode(), errorDescription, e);
     }
 
     public static IdentityRecoveryClientException handleClientException(IdentityRecoveryConstants.ErrorMessages error,
@@ -184,7 +181,7 @@ public class Utils {
         } else {
             errorDescription = error.getMessage();
         }
-        return IdentityException.error(IdentityRecoveryClientException.class, error.getCode(), errorDescription);
+        return new IdentityRecoveryClientException(error.getCode(), errorDescription);
     }
 
     public static IdentityRecoveryClientException handleClientException(IdentityRecoveryConstants.ErrorMessages error,
@@ -197,7 +194,7 @@ public class Utils {
         } else {
             errorDescription = error.getMessage();
         }
-        return IdentityException.error(IdentityRecoveryClientException.class, error.getCode(), errorDescription, e);
+        return new IdentityRecoveryClientException(error.getCode(), errorDescription, e);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,11 @@
                 <artifactId>in-memory-connectors-test-artifact</artifactId>
                 <version>${carbon.identity.mgt.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.mgt</groupId>
+                <artifactId>identity-store-interceptor-test-artifact</artifactId>
+                <version>${carbon.identity.mgt.version}</version>
+            </dependency>
 
             <!-- Identity Recovery -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
         <org.wso2.carbon.security.caas.version>1.0.0-m2</org.wso2.carbon.security.caas.version>
         <carbon.datasources.version>1.0.0</carbon.datasources.version>
         <carbon.jndi.version>1.0.0</carbon.jndi.version>
-        <carbon.identity.commons.version>1.0.0-SNAPSHOT</carbon.identity.commons.version>
+        <carbon.identity.commons.version>0.1.7-SNAPSHOT</carbon.identity.commons.version>
         <commons.lang.version>3.4</commons.lang.version>
         <jackson.version>1.8.6</jackson.version>
 

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -72,6 +72,12 @@
             <version>${carbon.datasources.version}</version>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.commons</groupId>
+            <artifactId>org.wso2.carbon.identity.common.feature</artifactId>
+            <version>${carbon.identity.commons.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -137,6 +143,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.datasource.core.feature</id>
                                     <version>${carbon.datasources.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.common.feature</id>
+                                    <version>${carbon.identity.commons.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -81,6 +81,14 @@
             <artifactId>in-memory-connectors-test-artifact</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.mgt</groupId>
+            <artifactId>identity-store-interceptor-test-artifact</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.commons</groupId>
+            <artifactId>org.wso2.carbon.identity.commons</artifactId>
+        </dependency>
 
         <!-- Pax Exam Dependencies-->
         <dependency>

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/identity/mgt/test/osgi/util/IdentityMgtOSGiTestUtils.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/identity/mgt/test/osgi/util/IdentityMgtOSGiTestUtils.java
@@ -101,6 +101,10 @@ public class IdentityMgtOSGiTestUtils {
                 .groupId("com.h2database")
                 .artifactId("h2")
                 .versionAsInProject());
+        defaultOptionList.add(mavenBundle()
+                .groupId("org.wso2.carbon.identity.commons")
+                .artifactId("org.wso2.carbon.identity.commons")
+                .versionAsInProject());
 
         CarbonSysPropConfiguration sysPropConfiguration = new CarbonSysPropConfiguration();
         sysPropConfiguration.setCarbonHome(getCarbonHome());

--- a/tests/osgi-tests/src/test/resources/carbon-home/conf/identity/identity.yaml
+++ b/tests/osgi-tests/src/test/resources/carbon-home/conf/identity/identity.yaml
@@ -1,0 +1,20 @@
+###############################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+###############################################################################
+
+identityStoreInterceptors:
+  - name: org.wso2.carbon.identity.mgt.test.identity.store.interceptor.TestIdentityStoreInterceptor
+    enable: true
+    orderID: 20

--- a/tests/test-artifacts/identity-store-interceptor-test-artifact/pom.xml
+++ b/tests/test-artifacts/identity-store-interceptor-test-artifact/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~                                                                         
+  ~ Licensed under the Apache License, Version 2.0 (the "License");         
+  ~ you may not use this file except in compliance with the License.        
+  ~ You may obtain a copy of the License at                                 
+  ~                                                                         
+  ~ http://www.apache.org/licenses/LICENSE-2.0                              
+  ~                                                                         
+  ~ Unless required by applicable law or agreed to in writing, software     
+  ~ distributed under the License is distributed on an "AS IS" BASIS,       
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and     
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.mgt</groupId>
+        <artifactId>carbon-identity-mgt-test-artifacts</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>identity-store-interceptor-test-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.mgt</groupId>
+            <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <private.package>org.wso2.carbon.identity.mgt.test.identity.store.interceptor.internal</private.package>
+        <export.package>
+            !org.wso2.carbon.identity.mgt.test.identity.store.interceptor.internal,
+            org.wso2.carbon.identity.mgt.test.identity.store.interceptor.*
+        </export.package>
+        <import.package>
+            org.osgi.framework.*;version="${osgi.framework.package.import.version.range}",
+            org.osgi.service.permissionadmin.*;version="${org.osgi.service.permissionadmin.import.version.range}",
+            org.slf4j.*;version="${slf4j.logging.package.import.version.range}",
+            javax.security.auth.*,
+            org.osgi.service.component.annotations.*;version="${org.osgi.service.component.annotations.version.range}",
+            org.wso2.carbon.identity.mgt.*;version="${org.wso2.carbon.identity.mgt.version.range}"
+        </import.package>
+
+        <dsannotations>*</dsannotations>
+
+        <carbon.component>
+            osgi.service;
+            objectClass="org.wso2.carbon.identity.mgt.interceptor.IdentityStoreInterceptor"
+        </carbon.component>
+
+        <!-- OSGi API version range-->
+        <osgi.framework.package.import.version.range>[1.8.0, 2.0.0)</osgi.framework.package.import.version.range>
+        <org.osgi.service.permissionadmin.import.version.range>[1.2.0, 1.3.0)
+        </org.osgi.service.permissionadmin.import.version.range>
+        <org.osgi.service.component.annotations.version.range>[1.2.0, 1.3.0)
+        </org.osgi.service.component.annotations.version.range>
+        <org.wso2.carbon.identity.mgt.version.range>[1.0.0, 1.1.0)</org.wso2.carbon.identity.mgt.version.range>
+
+        <!-- Dependency package version ranges -->
+
+        <!--Logging API version range-->
+        <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>
+
+    </properties>
+    
+</project>

--- a/tests/test-artifacts/identity-store-interceptor-test-artifact/src/main/java/org/wso2/carbon/identity/mgt/test/identity/store/interceptor/TestIdentityStoreInterceptor.java
+++ b/tests/test-artifacts/identity-store-interceptor-test-artifact/src/main/java/org/wso2/carbon/identity/mgt/test/identity/store/interceptor/TestIdentityStoreInterceptor.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package org.wso2.carbon.identity.mgt.interceptor;
-
+package org.wso2.carbon.identity.mgt.test.identity.store.interceptor;
 
 import org.wso2.carbon.identity.mgt.AuthenticationContext;
 import org.wso2.carbon.identity.mgt.Group;
@@ -28,560 +27,547 @@ import org.wso2.carbon.identity.mgt.exception.AuthenticationFailure;
 import org.wso2.carbon.identity.mgt.exception.GroupNotFoundException;
 import org.wso2.carbon.identity.mgt.exception.IdentityStoreException;
 import org.wso2.carbon.identity.mgt.exception.UserNotFoundException;
-import org.wso2.carbon.identity.mgt.impl.internal.IdentityMgtDataHolder;
-import org.wso2.carbon.identity.mgt.impl.internal.config.interceptor.InterceptorEntry;
+import org.wso2.carbon.identity.mgt.interceptor.AbstractIdentityStoreInterceptor;
 
 import java.util.List;
 import java.util.Set;
 import javax.security.auth.callback.Callback;
 
 /**
- * Abstract implementation IdentityStoreInterceptor.
- * @since 1.0.0
+ * Test identity store interceptor.
  */
-public class AbstractIdentityStoreInterceptor implements IdentityStoreInterceptor {
+public class TestIdentityStoreInterceptor extends AbstractIdentityStoreInterceptor {
 
-    private static final int DEFAULT_EXECUTION_ORDER_ID = 10;
 
-    @Override
-    public int getExecutionOrderId() {
-
-        InterceptorEntry interceptorEntry = IdentityMgtDataHolder.getInstance().getIdentityStoreInterceptorConfigMap
-                ().get(this.getClass().getCanonicalName());
-
-        if (interceptorEntry != null) {
-            return interceptorEntry.getOrderID();
-        }
-
-        return DEFAULT_EXECUTION_ORDER_ID;
-    }
+    public static final ThreadLocal<Boolean> PRE = new ThreadLocal<>();
+    public static final ThreadLocal<Boolean> POST = new ThreadLocal<>();
 
     @Override
     public void doPreGetUser(String uniqueUserId) throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetUser(String uniqueUserId, User user) throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetUser(Claim claim) throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetUser(Claim claim, User user) throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetUser(Claim claim, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetUser(Claim claim, String domainName, User user) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListUsers(int offset, int length) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListUsers(int offset, int length, List<User> users) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListUsers(int offset, int length, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListUsers(int offset, int length, String domainName, List<User> users)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListUsers(Claim claim, int offset, int length) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListUsers(Claim claim, int offset, int length, List<User> users) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListUsers(Claim claim, int offset, int length, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListUsers(Claim claim, int offset, int length, String domainName, List<User> users)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListUsers(MetaClaim metaClaim, String filterPattern, int offset, int length)
             throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListUsers(MetaClaim metaClaim, String filterPattern, int offset, int length, List<User> users)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListUsers(MetaClaim metaClaim, String filterPattern, int offset, int length, String domainName)
             throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListUsers(MetaClaim metaClaim, String filterPattern, int offset, int length, String domainName,
                                 List<User> users) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetGroup(String uniqueGroupId) throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetGroup(String uniqueGroupId, Group group)
             throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetGroup(Claim claim) throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetGroup(Claim claim, Group group) throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetGroup(Claim claim, String domainName) throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetGroup(Claim claim, String domainName, Group group)
             throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListGroups(int offset, int length) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListGroups(int offset, int length, List<Group> groups) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListGroups(int offset, int length, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListGroups(int offset, int length, String domainName, List<Group> groups)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListGroups(Claim claim, int offset, int length) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListGroups(Claim claim, int offset, int length, List<Group> groups)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListGroups(MetaClaim metaClaim, String filterPattern, int offset, int length)
             throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListGroups(MetaClaim metaClaim, String filterPattern, int offset, int length, List<Group> groups)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListGroups(MetaClaim metaClaim, String filterPattern, int offset, int length, String domainName)
             throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListGroups(MetaClaim metaClaim, String filterPattern, int offset, int length, String domainName,
                                  List<Group> groups) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreListGroups(Claim claim, int offset, int length, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostListGroups(Claim claim, int offset, int length, String domainName, List<Group> groups)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetGroupsOfUser(String uniqueUserId) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetGroupsOfUser(String uniqueUserId, List<Group> groups) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetUsersOfGroup(String uniqueGroupId) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetUsersOfGroup(String uniqueGroupId, List<User> users) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreIsUserInGroup(String uniqueUserId, String uniqueGroupId) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostIsUserInGroup(String uniqueUserId, String uniqueGroupId, Boolean isUserInGroup)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetClaimsOfUser(String uniqueUserId) throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetClaimsOfUser(String uniqueUserId, List<Claim> claims)
             throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetClaimsOfUser(String uniqueUserId, List<MetaClaim> metaClaims)
             throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetClaimsOfUser(String uniqueUserId, List<MetaClaim> metaClaims, List<Claim> claims)
             throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetClaimsOfGroup(String uniqueGroupId) throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetClaimsOfGroup(String uniqueGroupId, List<Claim> claims)
             throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetClaimsOfGroup(String uniqueGroupId, List<MetaClaim> metaClaims)
             throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetClaimsOfGroup(String uniqueGroupId, List<MetaClaim> metaClaims, List<Claim> claims)
             throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddUser(UserBean user) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddUser(UserBean userBean, User user) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddUser(UserBean user, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddUser(UserBean userBean, String domainName, User user) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddUsers(List<UserBean> usersBeans) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddUsers(List<UserBean> userBeans, List<User> users) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddUsers(List<UserBean> userBeans, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddUsers(List<UserBean> userBeans, String domainName, List<User> users)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateUserClaims(String uniqueUserId, List<Claim> claims)
             throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateUserClaims(String uniqueUserId, List<Claim> claims)
             throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateUserClaims(String uniqueUserId, List<Claim> claimsToAdd, List<Claim> claimsToRemove)
             throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateUserClaims(String uniqueUserId, List<Claim> claimsToAdd, List<Claim> claimsToRemove)
             throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateUserCredentials(String uniqueUserId, List<Callback> credentials)
             throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateUserCredentials(String uniqueUserId, List<Callback> credentials)
             throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateUserCredentials(String uniqueUserId, List<Callback> credentialsToAdd,
                                            List<Callback> credentialsToRemove)
             throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateUserCredentials(String uniqueUserId, List<Callback> credentialsToAdd,
                                             List<Callback> credentialsToRemove)
             throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreDeleteUser(String uniqueUserId) throws IdentityStoreException, UserNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostDeleteUser(String uniqueUserId) throws IdentityStoreException, UserNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateGroupsOfUser(String uniqueUserId, List<String> uniqueGroupIds)
             throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateGroupsOfUser(String uniqueUserId, List<String> uniqueGroupIds)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateGroupsOfUser(String uniqueUserId, List<String> uniqueGroupIdsToAdd,
                                         List<String> uniqueGroupIdsToRemove) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateGroupsOfUser(String uniqueUserId, List<String> uniqueGroupIdsToAdd,
                                          List<String> uniqueGroupIdsToRemove) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddGroup(GroupBean groupBean) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddGroup(GroupBean groupBean, Group group) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddGroup(GroupBean groupBean, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddGroup(GroupBean groupBean, String domainName, Group group) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddGroups(List<GroupBean> groups) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddGroups(List<GroupBean> groupBeans, List<Group> groups) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAddGroups(List<GroupBean> groups, String domainName) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAddGroups(List<GroupBean> groupBeans, String domainName, List<Group> groups)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateGroupClaims(String uniqueGroupId, List<Claim> claims)
             throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateGroupClaims(String uniqueGroupId, List<Claim> claims)
             throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateGroupClaims(String uniqueGroupId, List<Claim> claimsToAdd, List<Claim> claimsToRemove)
             throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateGroupClaims(String uniqueGroupId, List<Claim> claimsToAdd, List<Claim> claimsToRemove)
             throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreDeleteGroup(String uniqueGroupId) throws IdentityStoreException, GroupNotFoundException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostDeleteGroup(String uniqueGroupId) throws IdentityStoreException, GroupNotFoundException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateUsersOfGroup(String uniqueGroupId, List<String> uniqueUserIds)
             throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateUsersOfGroup(String uniqueGroupId, List<String> uniqueUserIds)
             throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreUpdateUsersOfGroup(String uniqueGroupId, List<String> uniqueUserIdsToAdd,
                                         List<String> uniqueUserIdsToRemove) throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostUpdateUsersOfGroup(String uniqueGroupId, List<String> uniqueUserIdsToAdd,
                                          List<String> uniqueUserIdsToRemove) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreAuthenticate(Claim claim, Callback[] credentials, String domainName)
             throws AuthenticationFailure, IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostAuthenticate(Claim claim, Callback[] credentials, String domainName,
                                    AuthenticationContext authenticationContext)
             throws AuthenticationFailure, IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetPrimaryDomainName() throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetPrimaryDomainName(String primaryDomainName) throws IdentityStoreException {
-
+        POST.set(true);
     }
 
     @Override
     public void doPreGetDomainNames() throws IdentityStoreException {
-
+        PRE.set(true);
     }
 
     @Override
     public void doPostGetDomainNames(Set<String> domainNames) throws IdentityStoreException {
-
+        POST.set(true);
     }
 }

--- a/tests/test-artifacts/identity-store-interceptor-test-artifact/src/main/java/org/wso2/carbon/identity/mgt/test/identity/store/interceptor/internal/TestIdentityStoreInterceptorComponent.java
+++ b/tests/test-artifacts/identity-store-interceptor-test-artifact/src/main/java/org/wso2/carbon/identity/mgt/test/identity/store/interceptor/internal/TestIdentityStoreInterceptorComponent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.test.identity.store.interceptor.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.identity.mgt.interceptor.IdentityStoreInterceptor;
+import org.wso2.carbon.identity.mgt.test.identity.store.interceptor.TestIdentityStoreInterceptor;
+
+/**
+ * OSGI component for test identity store interceptor.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.mgt.test.identity.store.interceptor.internal" +
+               ".TestIdentityStoreInterceptorComponent",
+        immediate = true
+)
+public class TestIdentityStoreInterceptorComponent {
+
+    private static final Logger log = LoggerFactory.getLogger(TestIdentityStoreInterceptorComponent.class);
+
+    @Activate
+    public void registerIdentityStoreInterceptor(BundleContext bundleContext) {
+        bundleContext.registerService(IdentityStoreInterceptor.class, new TestIdentityStoreInterceptor(), null);
+
+        log.info("TestIdentityStoreInterceptorComponent activated successfully.");
+
+    }
+
+}
+
+

--- a/tests/test-artifacts/pom.xml
+++ b/tests/test-artifacts/pom.xml
@@ -31,6 +31,7 @@
 
     <modules>
         <module>in-memory-connectors-test-artifact</module>
+        <module>identity-store-interceptor-test-artifact</module>
     </modules>
 
 </project>


### PR DESCRIPTION
- Adding identity interceptor OSGi tests.
- Adding support to configure interceptors from identity.yaml.

Sample identity store interceptor config
```yaml
identityStoreInterceptors:
  - name: org.wso2.carbon.identity.mgt.test.identity.store.interceptor.TestIdentityStoreInterceptor
    enable: true
    orderID: 20
```