### PR TITLE
Improvements to setClaimInIdentityStore method.

### DIFF
--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/event/IdentityMgtMessageContext.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/event/IdentityMgtMessageContext.java
@@ -23,6 +23,8 @@ import org.wso2.carbon.identity.common.base.event.EventContext;
  */
 public class IdentityMgtMessageContext extends EventContext {
 
+    private static final long serialVersionUID = -956376002689983602L;
+
     public IdentityMgtMessageContext() {
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
         <org.wso2.carbon.caching.version>1.0.0</org.wso2.carbon.caching.version>
         <carbon.datasources.version>1.0.0</carbon.datasources.version>
         <carbon.jndi.version>1.0.0</carbon.jndi.version>
-        <carbon.identity.commons.version>0.1.19</carbon.identity.commons.version>
+        <carbon.identity.commons.version>0.1.23</carbon.identity.commons.version>
         <commons.lang.version>3.4</commons.lang.version>
         <jackson.version>1.8.6</jackson.version>
 

--- a/tests/test-artifacts/identity-store-handler-test-artifact/src/main/java/org/wso2/carbon/identity/mgt/test/identity/store/handler/TestIdentityStoreHandler.java
+++ b/tests/test-artifacts/identity-store-handler-test-artifact/src/main/java/org/wso2/carbon/identity/mgt/test/identity/store/handler/TestIdentityStoreHandler.java
@@ -36,7 +36,7 @@ public class TestIdentityStoreHandler extends AbstractEventHandler {
         if ("PRE_GET_USER_BY_ID".equals(event.getEventName())) {
             PRE.set(true);
         } else if ("POST_GET_USER_BY_ID".equals(event.getEventName())) {
-            throw new IdentityException("Rollback test");
+            POST.set(true);
         } else if ("PRE_GET_USER_BY_CLAIM".equals(event.getEventName())) {
             PRE.set(true);
         } else if ("POST_GET_USER_BY_CLAIM".equals(event.getEventName())) {
@@ -236,9 +236,7 @@ public class TestIdentityStoreHandler extends AbstractEventHandler {
 
     @Override
     public void onFault(EventContext eventContext, Event event) throws IdentityException {
-        if ("POST_GET_USER_BY_ID".equals(event.getEventName())) {
-            POST.set(Boolean.TRUE);
-        }
+        POST.set(Boolean.FALSE);
     }
 
     @Override


### PR DESCRIPTION
- Changing `setClaimInIdentityStore` method signature to accept uniqueUserId
- Improving `setClaimInIdentityStore` claim update operation by using claim update PATCH operation.
- adding `setClaimsInIdentityStore` method do add multiple claims.