### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/JDBCUniqueIdResolver.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/JDBCUniqueIdResolver.java
@@ -363,11 +363,7 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
-            try {
-                UnitOfWork.rollBackTransaction(dataSource.getConnection());
-            } catch (SQLException e1) {
-                throw new UniqueIdResolverException("Error occurred while adding user.", e1);
-            }
+            UnitOfWork.rollbackTransaction(dataSource);
             throw new UniqueIdResolverException("Error while adding user.", e);
         }
 
@@ -420,11 +416,7 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
-            try {
-                UnitOfWork.rollBackTransaction(dataSource.getConnection());
-            } catch (SQLException e1) {
-                throw new UniqueIdResolverException("Error occurred while update user.", e1);
-            }
+            UnitOfWork.rollbackTransaction(dataSource);
             throw new UniqueIdResolverException("Error while adding user.", e);
         }
     }
@@ -464,11 +456,7 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
-            try {
-                UnitOfWork.rollBackTransaction(dataSource.getConnection());
-            } catch (SQLException e1) {
-                throw new UniqueIdResolverException("Error occurred while adding group.", e1);
-            }
+            UnitOfWork.rollbackTransaction(dataSource);
             throw new UniqueIdResolverException("Error while adding group.", e);
         }
 
@@ -521,11 +509,7 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
-            try {
-                UnitOfWork.rollBackTransaction(dataSource.getConnection());
-            } catch (SQLException e1) {
-                throw new UniqueIdResolverException("Error occurred while update group.", e1);
-            }
+            UnitOfWork.rollbackTransaction(dataSource);
             throw new UniqueIdResolverException("Error while adding user.", e);
         }
     }

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/JDBCUniqueIdResolver.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/JDBCUniqueIdResolver.java
@@ -363,6 +363,11 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
+            try {
+                UnitOfWork.rollBackTransaction(dataSource.getConnection());
+            } catch (SQLException e1) {
+                throw new UniqueIdResolverException("Error occurred while adding user.", e1);
+            }
             throw new UniqueIdResolverException("Error while adding user.", e);
         }
 
@@ -415,6 +420,11 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
+            try {
+                UnitOfWork.rollBackTransaction(dataSource.getConnection());
+            } catch (SQLException e1) {
+                throw new UniqueIdResolverException("Error occurred while update user.", e1);
+            }
             throw new UniqueIdResolverException("Error while adding user.", e);
         }
     }
@@ -454,6 +464,11 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
+            try {
+                UnitOfWork.rollBackTransaction(dataSource.getConnection());
+            } catch (SQLException e1) {
+                throw new UniqueIdResolverException("Error occurred while adding group.", e1);
+            }
             throw new UniqueIdResolverException("Error while adding group.", e);
         }
 
@@ -506,6 +521,11 @@ public class JDBCUniqueIdResolver implements UniqueIdResolver {
             namedPreparedStatement.getPreparedStatement().executeBatch();
             unitOfWork.endTransaction();
         } catch (SQLException e) {
+            try {
+                UnitOfWork.rollBackTransaction(dataSource.getConnection());
+            } catch (SQLException e1) {
+                throw new UniqueIdResolverException("Error occurred while update group.", e1);
+            }
             throw new UniqueIdResolverException("Error while adding user.", e);
         }
     }

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/util/UnitOfWork.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/util/UnitOfWork.java
@@ -25,7 +25,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 
 /**
  * Support class to implement Unit of work patter.
@@ -91,11 +90,11 @@ public class UnitOfWork implements AutoCloseable {
     /**
      * Revoke the transaction when catch then sql transaction errors.
      *
-     * @param dataSource DataSource of the connection.
+     * @param connection Database connection.
      */
-    public static void rollbackTransaction(DataSource dataSource) {
+    public static void rollbackTransaction(Connection connection) {
 
-        try (Connection connection = dataSource.getConnection()) {
+        try {
             if (connection != null) {
                 connection.rollback();
             }

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/util/UnitOfWork.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/util/UnitOfWork.java
@@ -88,6 +88,17 @@ public class UnitOfWork implements AutoCloseable {
     }
 
     /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param connection Database connection.
+     * @throws SQLException SQL Exception.
+     */
+    public static void rollBackTransaction(Connection connection) throws SQLException {
+
+        connection.rollback();
+    }
+
+    /**
      * Get the underlying connection object.
      *
      * @return instance of Connection.

--- a/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/util/UnitOfWork.java
+++ b/components/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/impl/util/UnitOfWork.java
@@ -25,6 +25,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.sql.DataSource;
 
 /**
  * Support class to implement Unit of work patter.
@@ -90,12 +91,17 @@ public class UnitOfWork implements AutoCloseable {
     /**
      * Revoke the transaction when catch then sql transaction errors.
      *
-     * @param connection Database connection.
-     * @throws SQLException SQL Exception.
+     * @param dataSource DataSource of the connection.
      */
-    public static void rollBackTransaction(Connection connection) throws SQLException {
+    public static void rollbackTransaction(DataSource dataSource) {
 
-        connection.rollback();
+        try (Connection connection = dataSource.getConnection()) {
+            if (connection != null) {
+                connection.rollback();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while rolling back transactions. ", e1);
+        }
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the carbon-identity-mgt repository, there are some places use the JDBC transaction but did not properly commit and rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5477